### PR TITLE
Provide own branch name regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Github workflow commit message check.
 name: Checks
 on: pull_request
 jobs:
-  commit-messages:
+  job-1:
     name: Commits Messages
     runs-on: ubuntu-latest
     steps:
@@ -19,4 +19,25 @@ jobs:
         run: ./github_actions.phar commit-messages
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  job-2:
+    name: Branch name convention
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup repository
+        run: git clone -n https://${{ github.actor }}:${{ github.token }}@github.com/${{ github.repository }}.git .
+      - name: Download phar file
+        run: wget https://github.com/devorto/github-actions/releases/latest/download/github_actions.phar
+      - name: Make executable
+        run: chmod +x github_actions.phar
+      - name: Run check
+        run: ./github_actions.phar commit-messages
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          branch_regex: '/^(feature|styling|bugfix)\/[0-9]+-[a-z0-9-]+$/'
+          decline_message: |
+            Invalid branch name.
+
+            Format should be: type/issue(or-ticket-number)-short-description
+            Type is one of the following: feature/bugfix/styling.
+            Short description should be lowercase a-z, 0-9 and - only.
 ```


### PR DESCRIPTION
Instead of write all kinds of complex checks, just provide a regex on how the branch name should look like. Also add option to provide your own decline message when it fails. And this check is not required for code owners.