### PR TITLE
Improve commit message check

### DIFF
--- a/src/Services/GithubApiCommands.php
+++ b/src/Services/GithubApiCommands.php
@@ -2,6 +2,8 @@
 
 namespace App\Services;
 
+use RuntimeException;
+
 /**
  * Class GithubApiCommands
  *
@@ -27,7 +29,7 @@ class GithubApiCommands
     /**
      * @param string $message
      */
-    public function placeIssueComment(string $message)
+    public function placeIssueComment(string $message): void
     {
         $curl = curl_init(sprintf(
             '%s/repos/%s/issues/%s/comments',
@@ -40,6 +42,79 @@ class GithubApiCommands
             [
                 CURLOPT_CUSTOMREQUEST => 'POST',
                 CURLOPT_POSTFIELDS => json_encode(['body' => $message]),
+                CURLOPT_HTTPHEADER => [
+                    'Accept: application/vnd.github.v3+json',
+                    'Content-Type: application/json',
+                    'Authorization: Token ' . $this->config->token(),
+                    'User-Agent: ' . $this->config->actor()
+                ]
+            ]
+        );
+        curl_exec($curl);
+        curl_close($curl);
+    }
+
+    /**
+     * @param string $commitHash
+     *
+     * @return array
+     */
+    public function getCommitComments(string $commitHash): array
+    {
+        $curl = curl_init(sprintf(
+            '%s/repos/%s/commits/%s/comments',
+            $this->config->apiUrl(),
+            $this->config->repository(),
+            $commitHash
+        ));
+        curl_setopt_array(
+            $curl,
+            [
+                CURLOPT_HTTPHEADER => [
+                    'Accept: application/vnd.github.v3+json',
+                    'Authorization: Token ' . $this->config->token(),
+                    'User-Agent: ' . $this->config->actor()
+                ],
+                CURLOPT_RETURNTRANSFER => true
+            ]
+        );
+        $data = curl_exec($curl);
+        $status = curl_getinfo($curl, CURLINFO_HTTP_CODE);
+        curl_close($curl);
+
+        if ($status !== 200) {
+            throw new RuntimeException(sprintf('Github endpoint error (%s): %s', $status, $data));
+        }
+
+        if (empty($data)) {
+            return [];
+        }
+
+        $data = json_decode($data, true);
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            throw new RuntimeException(json_last_error_msg());
+        }
+
+        return $data;
+    }
+
+    /**
+     * @param string $commitHash
+     * @param string $comment
+     */
+    public function placeCommitComment(string $commitHash, string $comment): void
+    {
+        $curl = curl_init(sprintf(
+            '%s/repos/%s/commits/%s/comments',
+            $this->config->apiUrl(),
+            $this->config->repository(),
+            $commitHash
+        ));
+        curl_setopt_array(
+            $curl,
+            [
+                CURLOPT_CUSTOMREQUEST => 'POST',
+                CURLOPT_POSTFIELDS => json_encode(['body' => $comment, 'position' => 0]),
                 CURLOPT_HTTPHEADER => [
                     'Accept: application/vnd.github.v3+json',
                     'Content-Type: application/json',


### PR DESCRIPTION
A few things have been altered in this check, namely:
* Don't throw a global vague message, but explain what is wrong in which commit.
    * Also place this message on the commit itself.
    * Created a list of "tests" and show this list and what is failing exactly.
* Don't allow repetitive commits (duplicate title check)