### PR TITLE
Add display of errors

### DIFF
--- a/src/Commands/CodeSniffer.php
+++ b/src/Commands/CodeSniffer.php
@@ -90,6 +90,9 @@ class CodeSniffer extends Command
                     $file,
                     $message['line']
                 );
+                $output->writeln('File: ' . $file);
+                $output->writeln('Line: ' . $message['line']);
+                $output->writeln('Message: ' . $message['message']);
             }
         }
 


### PR DESCRIPTION
The codesniffer action cannot be read in the github checks, by adding
the output lines we at least are able to see the messages in the checks.